### PR TITLE
Add Makefile as build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: install build
+
+install:
+	apt install upx-ucl
+	pip install pyinstaller
+
+build:
+	mkdir -p tmp
+	cp -r python tmp
+	rm -r tmp/python/enum
+	pyinstaller --onefile --name usqlfmt --icon=image/uroboroSQL_icon.ico tmp/python/uroborosqlfmt/api.py
+	rm -r tmp


### PR DESCRIPTION
# Task

* ビルドスクリプトを作成し、Python 3.9の環境でもビルド可能にしました
* WSL, git bashでの動作を確認しました

# Log

WSL

```sh
/mnt/c/Users/manoj/workspace/fork/uroboroSQL-formatter$ make build
mkdir -p tmp
cp -r python tmp
rm -r tmp/python/enum
pyinstaller --onefile --name usqlfmt --icon=image/uroboroSQL_icon.ico tmp/python/uroborosqlfmt/api.py
42 INFO: PyInstaller: 5.3
43 INFO: Python: 3.8.2
51 INFO: Platform: Linux-5.15.57.1-microsoft-standard-WSL2-x86_64-with-glibc2.29
58 INFO: wrote /mnt/c/Users/manoj/workspace/fork/uroboroSQL-formatter/usqlfmt.spec
62 INFO: UPX is available.
99 INFO: Extending PYTHONPATH with paths
['/mnt/c/Users/manoj/workspace/fork/uroboroSQL-formatter/tmp/python']
759 INFO: checking Analysis
763 INFO: Building Analysis because Analysis-00.toc is non existent
763 INFO: Initializing module dependency graph...
770 INFO: Caching module graph hooks...
780 INFO: Analyzing base_library.zip ...
5154 INFO: Processing pre-find module path hook distutils from '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks/pre_find_module_path/hook-distutils.py'.
5155 INFO: distutils: retargeting to non-venv dir '/usr/lib/python3.8'
7945 INFO: Caching module dependency graph...
8289 INFO: running Analysis Analysis-00.toc
8332 INFO: Analyzing /mnt/c/Users/manoj/workspace/fork/uroboroSQL-formatter/tmp/python/uroborosqlfmt/api.py
9413 INFO: Processing module hooks...
9413 INFO: Loading module hook 'hook-heapq.py' from '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks'...
9415 INFO: Loading module hook 'hook-pickle.py' from '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks'...
9417 INFO: Loading module hook 'hook-distutils.util.py' from '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks'...
9419 INFO: Loading module hook 'hook-distutils.py' from '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks'...
9430 INFO: Loading module hook 'hook-multiprocessing.util.py' from '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks'...
9431 INFO: Loading module hook 'hook-platform.py' from '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks'...
9432 INFO: Loading module hook 'hook-lib2to3.py' from '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks'...
9442 INFO: Loading module hook 'hook-xml.py' from '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks'...
9529 INFO: Loading module hook 'hook-difflib.py' from '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks'...
9531 INFO: Loading module hook 'hook-encodings.py' from '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks'...
10066 INFO: Loading module hook 'hook-xml.etree.cElementTree.py' from '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks'...
10067 INFO: Loading module hook 'hook-sysconfig.py' from '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks'...
10073 INFO: Looking for ctypes DLLs
11218 INFO: Analyzing run-time hooks ...
11221 INFO: Including run-time hook '/home/mano/.local/lib/python3.8/site-packages/PyInstaller/hooks/rthooks/pyi_rth_subprocess.py'
11225 INFO: Looking for dynamic libraries
13684 INFO: Looking for eggs
13684 INFO: Python library not in binary dependencies. Doing additional searching...
13703 INFO: Using Python library /lib/x86_64-linux-gnu/libpython3.8.so.1.0
13714 INFO: Warnings written to /mnt/c/Users/manoj/workspace/fork/uroboroSQL-formatter/build/usqlfmt/warn-usqlfmt.txt
13753 INFO: Graph cross-reference written to /mnt/c/Users/manoj/workspace/fork/uroboroSQL-formatter/build/usqlfmt/xref-usqlfmt.html
14083 INFO: checking PYZ
14086 INFO: Building PYZ because PYZ-00.toc is non existent
14087 INFO: Building PYZ (ZlibArchive) /mnt/c/Users/manoj/workspace/fork/uroboroSQL-formatter/build/usqlfmt/PYZ-00.pyz
14352 INFO: Building PYZ (ZlibArchive) /mnt/c/Users/manoj/workspace/fork/uroboroSQL-formatter/build/usqlfmt/PYZ-00.pyz completed successfully.
14366 INFO: checking PKG
14370 INFO: Building PKG because PKG-00.toc is non existent
14370 INFO: Building PKG (CArchive) usqlfmt.pkg
16794 INFO: Building PKG (CArchive) usqlfmt.pkg completed successfully.
16808 INFO: Bootloader /home/mano/.local/lib/python3.8/site-packages/PyInstaller/bootloader/Linux-64bit-intel/run
16808 INFO: checking EXE
16813 INFO: Building EXE because EXE-00.toc is non existent
16813 INFO: Building EXE from EXE-00.toc
16820 INFO: Copying bootloader EXE to /mnt/c/Users/manoj/workspace/fork/uroboroSQL-formatter/dist/usqlfmt
16832 INFO: Appending PKG archive to custom ELF section in EXE
16979 INFO: Building EXE from EXE-00.toc completed successfully.
rm -r tmp
/mnt/c/Users/manoj/workspace/fork/uroboroSQL-formatter$
```

Git Bash

```sh
manoj@DESKTOP-NQ2T791 MINGW64 ~/workspace/fork/uroboroSQL-formatter (master)
$ make build
mkdir -p tmp
cp -r python tmp
rm -r tmp/python/enum
pyinstaller --onefile --name usqlfmt --icon=image/uroboroSQL_icon.ico tmp/python/uroborosqlfmt/api.py
1026 INFO: PyInstaller: 5.3
1026 INFO: Python: 3.9.13
1040 INFO: Platform: Windows-10-10.0.22622-SP0
1041 INFO: wrote C:\Users\manoj\workspace\fork\uroboroSQL-formatter\usqlfmt.spec
2269 INFO: UPX is available.
2279 INFO: Extending PYTHONPATH with paths
['C:\\Users\\manoj\\workspace\\fork\\uroboroSQL-formatter\\tmp\\python']
3125 INFO: checking Analysis
3128 INFO: Building because inputs changed
3128 INFO: Initializing module dependency graph...
3146 INFO: Caching module graph hooks...
3195 INFO: Analyzing base_library.zip ...
8073 INFO: Processing pre-find module path hook distutils from 'C:\\Users\\manoj\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python39\\site-packages\\PyInstaller\\hooks\\pre_find_module_path\\hook-distutils.py'.
8081 INFO: distutils: retargeting to non-venv dir 'C:\\Program Files\\WindowsApps\\PythonSoftwareFoundation.Python.3.9_3.9.3568.0_x64__qbz5n2kfra8p0\\lib'
12228 INFO: Caching module dependency graph...
12456 INFO: running Analysis Analysis-00.toc
12481 INFO: Adding Microsoft.Windows.Common-Controls to dependent assemblies of final executable
  required by C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.3568.0_x64__qbz5n2kfra8p0\python.exe
13237 INFO: Analyzing C:\Users\manoj\workspace\fork\uroboroSQL-formatter\tmp\python\uroborosqlfmt\api.py
13598 INFO: Processing module hooks...
13599 INFO: Loading module hook 'hook-difflib.py' from 'C:\\Users\\manoj\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python39\\site-packages\\PyInstaller\\hooks'...
13608 INFO: Loading module hook 'hook-distutils.py' from 'C:\\Users\\manoj\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python39\\site-packages\\PyInstaller\\hooks'...
13616 INFO: Loading module hook 'hook-encodings.py' from 'C:\\Users\\manoj\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python39\\site-packages\\PyInstaller\\hooks'...
14176 INFO: Loading module hook 'hook-heapq.py' from 'C:\\Users\\manoj\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python39\\site-packages\\PyInstaller\\hooks'...
14185 INFO: Loading module hook 'hook-multiprocessing.util.py' from 'C:\\Users\\manoj\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python39\\site-packages\\PyInstaller\\hooks'...
14194 INFO: Loading module hook 'hook-pickle.py' from 'C:\\Users\\manoj\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python39\\site-packages\\PyInstaller\\hooks'...
14203 INFO: Loading module hook 'hook-platform.py' from 'C:\\Users\\manoj\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python39\\site-packages\\PyInstaller\\hooks'...
14212 INFO: Loading module hook 'hook-sysconfig.py' from 'C:\\Users\\manoj\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python39\\site-packages\\PyInstaller\\hooks'...
14221 INFO: Loading module hook 'hook-xml.py' from 'C:\\Users\\manoj\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python39\\site-packages\\PyInstaller\\hooks'...
14389 INFO: Looking for ctypes DLLs
14398 INFO: Analyzing run-time hooks ...
14401 INFO: Including run-time hook 'C:\\Users\\manoj\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python39\\site-packages\\PyInstaller\\hooks\\rthooks\\pyi_rth_subprocess.py'
14416 INFO: Looking for dynamic libraries
15443 INFO: Looking for eggs
15443 INFO: Using Python library C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.3568.0_x64__qbz5n2kfra8p0\python39.dll
15444 INFO: Found binding redirects:
[]
15448 INFO: Warnings written to C:\Users\manoj\workspace\fork\uroboroSQL-formatter\build\usqlfmt\warn-usqlfmt.txt
15485 INFO: Graph cross-reference written to C:\Users\manoj\workspace\fork\uroboroSQL-formatter\build\usqlfmt\xref-usqlfmt.html
15581 INFO: checking PYZ
15582 INFO: Building because name changed
15583 INFO: Building PYZ (ZlibArchive) C:\Users\manoj\workspace\fork\uroboroSQL-formatter\build\usqlfmt\PYZ-00.pyz
15944 INFO: Building PYZ (ZlibArchive) C:\Users\manoj\workspace\fork\uroboroSQL-formatter\build\usqlfmt\PYZ-00.pyz completed successfully.
15953 INFO: checking PKG
15953 INFO: Building because name changed
15953 INFO: Building PKG (CArchive) usqlfmt.pkg
18490 INFO: Building PKG (CArchive) usqlfmt.pkg completed successfully.
18494 INFO: Bootloader C:\Users\manoj\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\site-packages\PyInstaller\bootloader\Windows-64bit\run.exe
18494 INFO: checking EXE
18495 INFO: Rebuilding EXE-00.toc because usqlfmt.exe missing
18495 INFO: Building EXE from EXE-00.toc
18496 INFO: Copying bootloader EXE to C:\Users\manoj\workspace\fork\uroboroSQL-formatter\dist\usqlfmt.exe.notanexecutable
18607 INFO: Copying icon to EXE
18615 INFO: Copying icons from ['C:\\Users\\manoj\\workspace\\fork\\uroboroSQL-formatter\\image\\uroboroSQL_icon.ico']
18718 INFO: Writing RT_GROUP_ICON 0 resource with 104 bytes
18718 INFO: Writing RT_ICON 1 resource with 1384 bytes
18718 INFO: Writing RT_ICON 2 resource with 1736 bytes
18718 INFO: Writing RT_ICON 3 resource with 2216 bytes
18718 INFO: Writing RT_ICON 4 resource with 3752 bytes
18718 INFO: Writing RT_ICON 5 resource with 5672 bytes
18719 INFO: Writing RT_ICON 6 resource with 19496 bytes
18719 INFO: Writing RT_ICON 7 resource with 31750 bytes
18724 INFO: Copying 0 resources to EXE
18724 INFO: Embedding manifest in EXE
18726 INFO: Updating manifest in C:\Users\manoj\workspace\fork\uroboroSQL-formatter\dist\usqlfmt.exe.notanexecutable
18846 INFO: Updating resource type 24 name 1 language 0
18852 INFO: Appending PKG archive to EXE
18869 INFO: Fixing EXE headers
21196 INFO: Building EXE from EXE-00.toc completed successfully.
rm -r tmp

manoj@DESKTOP-NQ2T791 MINGW64 ~/workspace/fork/uroboroSQL-formatter (master)
```