### PR TITLE
Feature/support update return

### DIFF
--- a/python/sqlparse/keywords.py
+++ b/python/sqlparse/keywords.py
@@ -350,6 +350,7 @@ KEYWORDS = {
     'RESTRICT': tokens.Keyword,
     'RESULT': tokens.Keyword,
     'RETURN': tokens.Keyword,
+    'RETURNING': tokens.Keyword,
     'RETURNED_LENGTH': tokens.Keyword,
     'RETURNED_OCTET_LENGTH': tokens.Keyword,
     'RETURNED_SQLSTATE': tokens.Keyword,

--- a/python/uroborosqlfmt/api.py
+++ b/python/uroborosqlfmt/api.py
@@ -123,7 +123,7 @@ def __decode(text):
 def _parse_args(test_args=None):
     parser = argparse.ArgumentParser(description='uroboroSQL formatter API', prog='usqlfmt')
 
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s 0.1.0')
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s 0.1.4')
     parser.add_argument('input_path', \
         action='store', \
         type=str, \


### PR DESCRIPTION
## Diff

* [x] update cli tool version
    * hitect/uroboroSQL-formatter/issues/7
* [x] support `RETURNING` postgresql 
    * https://www.postgresql.jp/document/9.6/html/dml-returning.html
    * Since postgresql 8.2
    * https://github.com/future-architect/uroboroSQL-formatter/issues/9

## Change

Before

```sql
INSERT INTO users (id, user_name, user_addr) VALUES('001', 'hoge', 'tokyo') RETURNING user_id;
```

After

```sql
INSERT
INTO
	USERS
(
	ID
,	USER_NAME
,	USER_ADDR
) VALUES (
	'001'
,	'hoge'
,	'tokyo'
)	RETURNING
USER_ID
;
```