### PR TITLE
RETURNING句で改行が入らないケースがあったので追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /build
 /dist
 /usqlfmt.spec
+.idea

--- a/python/sqlparse/filters.py
+++ b/python/sqlparse/filters.py
@@ -336,7 +336,7 @@ class ReindentFilter(object):
     def _split_kwds(self, tlist):
         split_words = ('FROM', 'STRAIGHT_JOIN$', 'JOIN$', 'AND', 'OR',
                        'GROUP', 'ORDER', 'UNION', 'VALUES',
-                       'SET', 'BETWEEN', 'EXCEPT', 'HAVING')
+                       'SET', 'BETWEEN', 'EXCEPT', 'HAVING', "RETURNING")
 
         def _next_token(i):
             t = tlist.token_next_match(i, T.Keyword, split_words,

--- a/python/sqlparse/lexer.py
+++ b/python/sqlparse/lexer.py
@@ -86,7 +86,7 @@ class LexerMeta(type):
                                   " %r of %r: %s"
                                   % (tdef[0], state, cls, err)))
 
-            assert type(tdef[1]) is tokens._TokenType or isinstance(tdef[1], collections.Callable), \
+            assert type(tdef[1]) is tokens._TokenType or isinstance(tdef[1], collections.abc.Callable), \
                    ('token type must be simple type or callable, not %r'
                     % (tdef[1],))
 

--- a/python/sqlparse/lexer.py
+++ b/python/sqlparse/lexer.py
@@ -19,6 +19,12 @@ from sqlparse import tokens
 from sqlparse.keywords import KEYWORDS, KEYWORDS_COMMON
 import collections
 
+try:
+    collections.Callable = collections.abc.Callable
+except AttributeError:
+    # compatible for Python 3.10~
+    pass
+
 
 class include(str):
     pass
@@ -86,7 +92,7 @@ class LexerMeta(type):
                                   " %r of %r: %s"
                                   % (tdef[0], state, cls, err)))
 
-            assert type(tdef[1]) is tokens._TokenType or isinstance(tdef[1], collections.abc.Callable), \
+            assert type(tdef[1]) is tokens._TokenType or isinstance(tdef[1], collections.Callable), \
                    ('token type must be simple type or callable, not %r'
                     % (tdef[1],))
 

--- a/python/test/test_for_beta.py
+++ b/python/test/test_for_beta.py
@@ -81,6 +81,18 @@ SELECT * FROM tab2 ORDER BY c02 FETCH FIRST 50 PERCENT ROWS ONLY
       ( select * from staff T2 where T1.staff_id = T2.manager_id)
         """), u'SELECT\n\t*\nFROM\n\tSTAFF\tT1\nWHERE\n\tNOT\tEXISTS(\n\t\tSELECT\n\t\t\t*\n\t\tFROM\n\t\t\tSTAFF\tT2\n\t\tWHERE\n\t\t\tT1.STAFF_ID\t=\tT2.MANAGER_ID\n\t)') # pylint: disable=line-too-long
 
+    # Returning句のテスト
+    def test7(self):
+        self.assertEqual(format_sql(u"""
+    UPDATE products SET price = price * 1.10
+  WHERE price <= 99.99 RETURNING name, price AS new_price;
+        """), u'UPDATE\n\tPRODUCTS\nSET\tPRICE\t=\tPRICE\t*\t1.10\nWHERE\n\tPRICE\t<=\t99.99\nRETURNING\n\tNAME\n,\tPRICE\tAS\tNEW_PRICE\n;\n') # pylint: disable=line-too-long
+        self.assertEqual(format_sql(u"""
+   INSERT INTO users (firstname, lastname) VALUES ('Joe', 'Cool') RETURNING id, firstname, lastname;
+        """), u"""INSERT\nINTO\n\tUSERS\n(\n\tFIRSTNAME\n,\tLASTNAME\n) VALUES (\n\t'Joe'\n,\t'Cool'\n)\nRETURNING\n\tID\n,\tFIRSTNAME\n,\tLASTNAME\n;\n""") # pylint: disable=line-too-long
+        self.assertEqual(format_sql(u"""
+   DELETE FROM products WHERE obsoletion_date = 'today' RETURNING *;
+        """), u"""DELETE\nFROM\n\tPRODUCTS\nWHERE\n\tOBSOLETION_DATE\t=\t'today'\nRETURNING\t*\n;\n""") # pylint: disable=line-too-long
 
 
 def format_sql(text):

--- a/python/uroborosqlfmt/grouping.py
+++ b/python/uroborosqlfmt/grouping.py
@@ -429,7 +429,7 @@ class _SimpleWordsTokenHitTests(_WordsTokenHitTests):
             return lambda t: self._test_word(jdg, t)
         elif isinstance(jdg, type(T.Token)):
             return lambda t: t.ttype in jdg
-        elif isinstance(jdg, collections.Iterable):
+        elif isinstance(jdg, collections.abc.Iterable):
             def itr_hit_test(tkn):
                 for elm in jdg:
                     if self.__to_hit_test(elm)(tkn):

--- a/python/uroborosqlfmt/grouping.py
+++ b/python/uroborosqlfmt/grouping.py
@@ -10,6 +10,12 @@ from uroborosqlfmt.sql import WithinGroupFunctions, Phrase, AscDesc, OffsetFetch
     StartWith, With, LimitOffset, SpecialFunctionParameter, Calculation
 from uroborosqlfmt.exceptions import SqlFormatterException
 
+try:
+    collections.Iterable = collections.abc.Iterable
+except AttributeError:
+    # compatible for Python 3.10~
+    pass
+
 def _remove_split_token(token, new_parent):
     parent = token.parent
     tokens = []
@@ -429,7 +435,7 @@ class _SimpleWordsTokenHitTests(_WordsTokenHitTests):
             return lambda t: self._test_word(jdg, t)
         elif isinstance(jdg, type(T.Token)):
             return lambda t: t.ttype in jdg
-        elif isinstance(jdg, collections.abc.Iterable):
+        elif isinstance(jdg, collections.Iterable):
             def itr_hit_test(tkn):
                 for elm in jdg:
                     if self.__to_hit_test(elm)(tkn):


### PR DESCRIPTION
RETURNING句がキーワード追加だけだと、特にupdate文で想定どおりに動かないことがわかったので、修正しました

## update

```sql
-- before
 UPDATE products SET price = price * 1.10
  WHERE price <= 99.99 RETURNING name, price AS new_price;

-- after
UPDATE
	PRODUCTS
SET	PRICE	=	PRICE	*	1.10
WHERE
	PRICE	<=	99.99
RETURNING
	NAME
,	PRICE	AS	NEW_PRICE
;
```

## insert
```sql
-- before
INSERT INTO users (firstname, lastname) VALUES ('Joe', 'Cool') RETURNING id, firstname, lastname;

-- after
INSERT
INTO
	USERS
(
	FIRSTNAME
,	LASTNAME
) VALUES (
	'Joe'
,	'Cool'
)
RETURNING
	ID
,	FIRSTNAME
,	LASTNAME
;
```

## delete

```sql
-- before
DELETE FROM products WHERE obsoletion_date = 'today' RETURNING *;

--after
DELETE
FROM
	PRODUCTS
WHERE
	OBSOLETION_DATE	=	'today'
RETURNING	*
;
```