### PR TITLE
Feature/linefeed

### DIFF
--- a/python/sqlparse/engine/__init__.py
+++ b/python/sqlparse/engine/__init__.py
@@ -4,7 +4,6 @@
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php.
 
 """filter"""
-import uroborosqlfmt
 from sqlparse import lexer
 from sqlparse.engine import grouping
 from sqlparse.engine.filter import StatementFilter

--- a/python/sqlparse/engine/__init__.py
+++ b/python/sqlparse/engine/__init__.py
@@ -4,6 +4,7 @@
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php.
 
 """filter"""
+
 from sqlparse import lexer
 from sqlparse.engine import grouping
 from sqlparse.engine.filter import StatementFilter

--- a/python/sqlparse/engine/__init__.py
+++ b/python/sqlparse/engine/__init__.py
@@ -4,7 +4,7 @@
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php.
 
 """filter"""
-
+import uroborosqlfmt
 from sqlparse import lexer
 from sqlparse.engine import grouping
 from sqlparse.engine.filter import StatementFilter

--- a/python/sqlparse/engine/filter.py
+++ b/python/sqlparse/engine/filter.py
@@ -77,13 +77,22 @@ class StatementFilter:
         splitlevel = 0
         stmt = None
         stmt_tokens = []
+        stmt_cnt = 0
 
         # Run over all stream tokens
         for ttype, value in stream:
             # Yield token if we finished a statement and there's no whitespaces
             if consume_ws and ttype not in (T.Whitespace, T.Comment.Single):
+                if stmt_cnt > 0:
+                    cr_tokens = [Token(T.Whitespace.Newline, "\n")]
+                    crstmt = Statement()
+                    crstmt.tokens = cr_tokens
+                    yield crstmt
+
                 stmt.tokens = stmt_tokens
                 yield stmt
+
+                stmt_cnt += 1
 
                 # Reset filter and prepare to process next statement
                 self._reset()

--- a/python/test/test_for_beta.py
+++ b/python/test/test_for_beta.py
@@ -94,6 +94,13 @@ SELECT * FROM tab2 ORDER BY c02 FETCH FIRST 50 PERCENT ROWS ONLY
    DELETE FROM products WHERE obsoletion_date = 'today' RETURNING *;
         """), u"""DELETE\nFROM\n\tPRODUCTS\nWHERE\n\tOBSOLETION_DATE\t=\t'today'\nRETURNING\t*\n;\n""") # pylint: disable=line-too-long
 
+    # Multiple SQL in a file.
+    def test7(self):
+        self.assertEqual(format_sql(u"""
+    select * from users;
+    select * from product;
+    """), u'SELECT\n\t*\nFROM\n\tUSERS\n;\n\nSELECT\n\t*\nFROM\n\tPRODUCT\n;\n')
+
 
 def format_sql(text):
     formated = uroborosqlfmt.format_sql(text, LocalConfig())

--- a/python/test/test_for_beta.py
+++ b/python/test/test_for_beta.py
@@ -96,11 +96,18 @@ SELECT * FROM tab2 ORDER BY c02 FETCH FIRST 50 PERCENT ROWS ONLY
 
     # Multiple SQL in a file.
     def test7(self):
+        # two sql
         self.assertEqual(format_sql(u"""
     select * from users;
     select * from product;
     """), u'SELECT\n\t*\nFROM\n\tUSERS\n;\n\nSELECT\n\t*\nFROM\n\tPRODUCT\n;\n')
 
+        # three sql
+        self.assertEqual(format_sql(u"""
+    select * from users;
+    select * from product;
+    select * from area;
+    """), u'SELECT\n\t*\nFROM\n\tUSERS\n;\n\nSELECT\n\t*\nFROM\n\tPRODUCT\n;\n\nSELECT\n\t*\nFROM\n\tAREA\n;\n')
 
 def format_sql(text):
     formated = uroborosqlfmt.format_sql(text, LocalConfig())


### PR DESCRIPTION
# Issue

https://github.com/future-architect/uroboroSQL-formatter/issues/13

# Description

* #13 の通り、1ファイルに複数SQL（;で区切られたクエリやステートメント）が存在するときに、現在だと空行が存在しませんが、空行を入れたい
* [フューチャーSQLコーディング規約](https://future-architect.github.io/coding-standards/documents/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88Oracle%EF%BC%89.html) には、1ファイル中の複数SQL間同士の改行についての記載は見あたらない
    * 項目間については存在するが、セミコロンで区切られたSQLについては記載が無い
    * 未定義なので受け入れられるのでは？
    * 